### PR TITLE
Parse url options when passed options are a string

### DIFF
--- a/src/cache.js
+++ b/src/cache.js
@@ -16,6 +16,7 @@ var fs = require('fs');
 var replayerUtil = require('./util');
 var EventEmitter = require('events').EventEmitter;
 var http = require('http');
+var url = require('url');
 
 var playbackHits = true;
 var recordMisses = true;
@@ -116,6 +117,12 @@ module.exports.isEnabled = function isEnabled() {
   protocolModule.globalAgent.maxSockets = 1000;
 
   protocolModule.__replayerRequest = protocolModule.request = function replayerRequest(options, callback) {
+    if (typeof options === 'string') {
+      options = url.parse(options);
+      if (!options.hostname) {
+        throw new Error('Unable to determine the domain name');
+      }
+    }
     var reqUrl = replayerUtil.urlFromHttpRequestOptions(options, protocol);
     var reqBody = [];
     var debug = replayerUtil.shouldFindMatchingFixtures();

--- a/test/cache.js
+++ b/test/cache.js
@@ -88,6 +88,16 @@ describe('cache.js', function() {
         require('https').request.name.should.not.equal('replayerRequest');
       });
     });
-  });
 
+    describe('#http.request override', function () {
+      it('does not blow up when options is a string', function () {
+        cache.enable();
+        var get = require('http').get;
+        var getRequestWithStringOptions = function () {
+          get('http://example.com');
+        };
+        getRequestWithStringOptions.should.not.throw();
+      });
+    });
+  });
 });


### PR DESCRIPTION
This prevents #urlFromHttpRequestOptions from blowing up, and preserves the expected behaviour of http.request and https.request when options are strings