### PR TITLE
Parse url options when passed options are a string

### DIFF
--- a/src/cache.js
+++ b/src/cache.js
@@ -116,7 +116,12 @@ module.exports.isEnabled = function isEnabled() {
   protocolModule.globalAgent.maxSockets = 1000;
 
   protocolModule.__replayerRequest = protocolModule.request = function replayerRequest(options, callback) {
-    var reqUrl = replayerUtil.urlFromHttpRequestOptions(options, protocol);
+    var reqUrl;
+    if (typeof options === 'string') {
+      reqUrl = options;
+    } else {
+      reqUrl = replayerUtil.urlFromHttpRequestOptions(options, protocol);
+    }
     var reqBody = [];
     var debug = replayerUtil.shouldFindMatchingFixtures();
 

--- a/test/cache.js
+++ b/test/cache.js
@@ -90,4 +90,27 @@ describe('cache.js', function() {
     });
   });
 
+  describe('Overrides', function () {
+    describe('#http.request', function () {
+      it('does not blow up when options is a string', function () {
+        cache.enable();
+        var get = require('http').get;
+        var getRequestWithStringOptions = function () {
+          get('http://example.com');
+        };
+        getRequestWithStringOptions.should.not.throw();
+      });
+    });
+
+    describe('#https.request', function () {
+      it('does not blow up when options is a string', function () {
+        cache.enable();
+        var get = require('https').get;
+        var getRequestWithStringOptions = function () {
+          get('https://example.com');
+        };
+        getRequestWithStringOptions.should.not.throw();
+      });
+    });
+  });
 });


### PR DESCRIPTION
This prevents #urlFromHttpRequestOptions from blowing up, and preserves the expected behaviour of http.request and https.request when options are strings